### PR TITLE
Correction de l'auto-closing tag <Layout>

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -2,16 +2,17 @@
 import Layout from "../layouts/Layout.astro";
 import Tarifs from "../components/Tarifs.astro";
 const {
-    metaTitle = "À propos",
-    metaDescription = "",
-    pageTitle = "À propos",
-    pageDescription = "",
+  metaTitle = "À propos",
+  metaDescription = "",
+  pageTitle = "À propos",
+  pageDescription = "",
 } = Astro.props;
 ---
 
-<Layout title={metaTitle} />
-<header>
+<Layout title={metaTitle}>
+  <header>
     <h1>{pageTitle}</h1>
     {pageDescription && <p>{pageDescription}</p>}
     <Tarifs />
-</header>
+  </header>
+</Layout>

--- a/src/pages/exposants.astro
+++ b/src/pages/exposants.astro
@@ -1,15 +1,16 @@
 ---
 import Layout from "../layouts/Layout.astro";
 const {
-    metaTitle = "Exposants",
-    metaDescription = "",
-    pageTitle = "Exposants",
-    pageDescription = "",
+  metaTitle = "Exposants",
+  metaDescription = "",
+  pageTitle = "Exposants",
+  pageDescription = "",
 } = Astro.props;
 ---
 
-<Layout title={metaTitle} />
-<header>
+<Layout title={metaTitle}>
+  <header>
     <h1>{pageTitle}</h1>
     {pageDescription && <p>{pageDescription}</p>}
-</header>
+  </header>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,9 +10,10 @@ const {
 } = Astro.props;
 ---
 
-<Layout title={metaTitle} />
-<header>
-  <h1>{pageTitle}</h1>
-  {pageDescription && <p>{pageDescription}</p>}
-</header>
-<Inscription />
+<Layout title={metaTitle}>
+  <header>
+    <h1>{pageTitle}</h1>
+    {pageDescription && <p>{pageDescription}</p>}
+  </header>
+  <Inscription />
+</Layout>

--- a/src/pages/infos.astro
+++ b/src/pages/infos.astro
@@ -1,15 +1,16 @@
 ---
 import Layout from "../layouts/Layout.astro";
 const {
-    metaTitle = "Informations pratiques",
-    metaDescription = "",
-    pageTitle = "Informations pratiques",
-    pageDescription = "",
+  metaTitle = "Informations pratiques",
+  metaDescription = "",
+  pageTitle = "Informations pratiques",
+  pageDescription = "",
 } = Astro.props;
 ---
 
-<Layout title={metaTitle} />
-<header>
+<Layout title={metaTitle}>
+  <header>
     <h1>{pageTitle}</h1>
     {pageDescription && <p>{pageDescription}</p>}
-</header>
+  </header>
+</Layout>

--- a/src/pages/media.astro
+++ b/src/pages/media.astro
@@ -1,15 +1,16 @@
 ---
 import Layout from "../layouts/Layout.astro";
 const {
-    metaTitle = "Médias et Presse",
-    metaDescription = "",
-    pageTitle = "Médias et Presse",
-    pageDescription = "",
+  metaTitle = "Médias et Presse",
+  metaDescription = "",
+  pageTitle = "Médias et Presse",
+  pageDescription = "",
 } = Astro.props;
 ---
 
-<Layout title={metaTitle} />
-<header>
+<Layout title={metaTitle}>
+  <header>
     <h1>{pageTitle}</h1>
     {pageDescription && <p>{pageDescription}</p>}
-</header>
+  </header>
+</Layout>

--- a/src/pages/mentions.astro
+++ b/src/pages/mentions.astro
@@ -1,15 +1,16 @@
 ---
 import Layout from "../layouts/Layout.astro";
 const {
-    metaTitle = "Mentions légales",
-    metaDescription = "",
-    pageTitle = "Mentions légales",
-    pageDescription = "",
+  metaTitle = "Mentions légales",
+  metaDescription = "",
+  pageTitle = "Mentions légales",
+  pageDescription = "",
 } = Astro.props;
 ---
 
-<Layout title={metaTitle} />
-<header>
+<Layout title={metaTitle}>
+  <header>
     <h1>{pageTitle}</h1>
     {pageDescription && <p>{pageDescription}</p>}
-</header>
+  </header>
+</Layout>


### PR DESCRIPTION
Corrige l'auto-closing qui cassait le layout dans :
- about.astro
- exposants.astro
- index.astro
- infos.astro
- media.astro
- mentions.astro